### PR TITLE
Fix misc VCD parser bugs

### DIFF
--- a/vcd/parser.py
+++ b/vcd/parser.py
@@ -183,14 +183,14 @@ class VCDParser:
 
     def vcd_end(self, tokeniser, keyword):
         if not self.end_of_definitions:
-            parse_error(tokeniser, keyword)
+            self.parse_error(tokeniser, keyword)
 
     # Actual parse routines
     def update_time(self, next_time):
         """Reached an update point in time in the VCD - use the collected changes
      and update any watchers that are sensitive to a signal that has changed"""
         current_time = self.now
-        if self.logger.getEffectiveLevel == logging.DEBUG:
+        if self.logger.getEffectiveLevel() == logging.DEBUG:
             self.logger.debug(
                 "End of time %s, processing sensitivity lists. Changes:", current_time
             )

--- a/vcd/tracker.py
+++ b/vcd/tracker.py
@@ -35,7 +35,7 @@ class VCDTracker:
         return id
 
     def start(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def notify(self, activity, values):
         self.trigger_count += 1
@@ -44,4 +44,4 @@ class VCDTracker:
         self.update()
 
     def update(self):
-        raise NotImplemented
+        raise NotImplementedError

--- a/vcd/watcher.py
+++ b/vcd/watcher.py
@@ -126,4 +126,4 @@ class VCDWatcher:
     # (for instance, only on rising clock edges)
     def should_notify(self):
         # Called every time something in the sensitivity list changes
-        return true
+        return True


### PR DESCRIPTION
## Summary
- fix default watcher `should_notify` return value
- call `self.parse_error` in `vcd_end`
- correctly call `logger.getEffectiveLevel()`
- raise `NotImplementedError` in tracker base class

## Testing
- `PYTHONPATH=. python examples/ubus/ubus_test.py examples/ubus/ubus.vcd`

------
https://chatgpt.com/codex/tasks/task_e_684632296fdc8331bb1c9d644fc88da9